### PR TITLE
III-1294: Also update contactinfo on an event, when updating a place

### DIFF
--- a/src/ReadModel/RelationsToCdbXmlProjector.php
+++ b/src/ReadModel/RelationsToCdbXmlProjector.php
@@ -194,7 +194,7 @@ class RelationsToCdbXmlProjector implements EventListenerInterface
 
             $eventContactInfo = $event->getContactInfo();
             if (is_null($eventContactInfo)) {
-              $eventContactInfo = new CultureFeed_Cdb_Data_ContactInfo();
+                $eventContactInfo = new CultureFeed_Cdb_Data_ContactInfo();
             }
 
             foreach ($eventContactInfo->getAddresses() as $index => $address) {

--- a/src/ReadModel/RelationsToCdbXmlProjector.php
+++ b/src/ReadModel/RelationsToCdbXmlProjector.php
@@ -6,7 +6,6 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventHandling\EventListenerInterface;
 use CultureFeed_Cdb_Data_ContactInfo;
-use CultureFeed_Cdb_Item_Base;
 use CultureFeed_Cdb_Item_Event;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
@@ -19,7 +18,6 @@ use CultuurNet\UDB3\CdbXmlService\ReadModel\Repository\DocumentRepositoryInterfa
 use CultuurNet\UDB3\CdbXmlService\ReadModel\Repository\OfferRelationsServiceInterface;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactory;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
-use RuntimeException;
 use ValueObjects\Web\Url;
 
 /**
@@ -186,11 +184,6 @@ class RelationsToCdbXmlProjector implements EventListenerInterface
             $newEvent = clone $event;
 
             $newEvent->setLocation($location);
-
-            $event = EventItemFactory::createEventFromCdbXml(
-                'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL',
-                $eventCdbXml->getCdbXml()
-            );
 
             $eventContactInfo = $event->getContactInfo();
             if (is_null($eventContactInfo)) {

--- a/tests/ReadModel/Repository/samples/event-with-place-2.xml
+++ b/tests/ReadModel/Repository/samples/event-with-place-2.xml
@@ -22,10 +22,10 @@
     <contactinfo>
       <address>
         <physical>
-          <city>$locality</city>
-          <country>$country</country>
-          <street>$street</street>
-          <zipcode>$postalCode</zipcode>
+          <city>Leuven</city>
+          <country>België</country>
+          <street>Teststraat</street>
+          <zipcode>3000</zipcode>
         </physical>
       </address>
     </contactinfo>

--- a/tests/ReadModel/Repository/samples/event-with-place.xml
+++ b/tests/ReadModel/Repository/samples/event-with-place.xml
@@ -22,10 +22,10 @@
     <contactinfo>
       <address>
         <physical>
-          <city>$locality</city>
-          <country>$country</country>
-          <street>$street</street>
-          <zipcode>$postalCode</zipcode>
+          <city>Leuven</city>
+          <country>België</country>
+          <street>Teststraat</street>
+          <zipcode>3000</zipcode>
         </physical>
       </address>
     </contactinfo>


### PR DESCRIPTION
When updating a place the relations projector will update the location on all events that use that place. Contactinfo was not updated, but this needs to be done. Fixed here.