### PR TITLE
III-1965 Apply UiTPAS labels on copied event.

### DIFF
--- a/src/ReadModel/OfferToCdbXmlProjector.php
+++ b/src/ReadModel/OfferToCdbXmlProjector.php
@@ -640,6 +640,21 @@ class OfferToCdbXmlProjector implements EventListenerInterface, LoggerAwareInter
         foreach ($keywords as $keyword) {
             $event->deleteKeyword($keyword);
         }
+        // But add the UiTPAS keywords again from the organizer.
+        $organiserCdbId = $this->eventCdbIdExtractor->getRelatedOrganizerCdbId($event);
+        if ($organiserCdbId) {
+            $actorCdbXml = $this->actorDocumentRepository->get($organiserCdbId);
+            $actor = ActorItemFactory::createActorFromCdbXml(
+                'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL',
+                $actorCdbXml->getCdbXml()
+            );
+            if ($actor) {
+                $event = $this->uitpasLabelApplier->addLabels(
+                    $event,
+                    LabelCollection::fromStrings($actor->getKeywords())
+                );
+            }
+        }
 
         // Update metadata like created-by, creation-date, last-updated and last-updated-by.
         // Make sure to first clear created-by and creation-date else they won't be updated.

--- a/tests/ReadModel/OfferToCdbXmlProjectorTest.php
+++ b/tests/ReadModel/OfferToCdbXmlProjectorTest.php
@@ -325,7 +325,7 @@ class OfferToCdbXmlProjectorTest extends CdbXmlProjectorTestBase
     /**
      * @test
      */
-    public function it_projects_event_copied()
+    public function it_should_keep_uitpas_labels_when_an_event_gets_copied()
     {
         $originalEventId = '404EE8DE-E828-9C07-FE7D12DC4EB24480';
         $eventId = '8b1855f7-7f11-4653-9fbb-f5f4611f7960';

--- a/tests/ReadModel/OfferToCdbXmlProjectorTest.php
+++ b/tests/ReadModel/OfferToCdbXmlProjectorTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractor;
+use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Cdb\ExternalId\ArrayMappingService;
 use CultuurNet\UDB3\CdbXmlService\CultureFeed\AddressFactory;
 use CultuurNet\UDB3\CdbXmlService\Labels\LabelApplierInterface;
@@ -55,6 +56,7 @@ use CultuurNet\UDB3\Event\ValueObjects\Audience;
 use CultuurNet\UDB3\Event\ValueObjects\AudienceType;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\LabelCollection;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Location\Location;
 use CultuurNet\UDB3\Media\Image;
@@ -332,8 +334,23 @@ class OfferToCdbXmlProjectorTest extends CdbXmlProjectorTestBase
             $originalEventId,
             $this->loadCdbXmlFromFile('event-copied-original.xml')
         );
-
         $this->repository->save($cdbXmlDocument);
+
+        $organizerId = 'ORG-123';
+        $organizerCdbxml = new CdbXmlDocument(
+            $organizerId,
+            $this->loadCdbXmlFromFile('actor-with-uitpas-keyword.xml')
+        );
+        $this->actorRepository->save($organizerCdbxml);
+
+        $this->uitpasLabelApplier->expects($this->once())
+            ->method('addLabels')
+            ->willReturnCallback(
+                function (\CultureFeed_Cdb_Item_Event $event) {
+                    $event->addKeyword('Paspartoe');
+                    return $event;
+                }
+            );
 
         $eventCopied = new EventCopied(
             $eventId,

--- a/tests/ReadModel/Repository/samples/actor-with-uitpas-keyword.xml
+++ b/tests/ReadModel/Repository/samples/actor-with-uitpas-keyword.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdbxml xmlns="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL/CdbXSD.xsd">
+  <actor cdbid="ORG-123" createdby="foobar" creationdate="2016-04-15T11:01:47" externalurl="http://foo.be/item/ORG-123" lastupdated="2016-04-15T11:01:47" lastupdatedby="foo@bar.com">
+    <actordetails>
+      <actordetail lang="nl">
+        <title>DE Studio</title>
+      </actordetail>
+    </actordetails>
+    <categories>
+      <category catid="8.11.0.0.0" type="actortype">Organisator(en)</category>
+    </categories>
+    <keywords>
+      <keyword>Paspartoe</keyword>
+    </keywords>
+  </actor>
+</cdbxml>

--- a/tests/ReadModel/Repository/samples/event-copied-original.xml
+++ b/tests/ReadModel/Repository/samples/event-copied-original.xml
@@ -48,8 +48,12 @@
       <label cdbid="C4ACF936-1D5F-48E8-B2EC-863B313CBDE6">Bibberburcht</label>
     </location>
     <keywords>
+      <keyword>Paspartoe</keyword>
       <keyword>2dotstwice</keyword>
       <keyword visible="false">cultuurnet</keyword>
     </keywords>
+    <organiser>
+      <label cdbid="ORG-123">DE Studio</label>
+    </organiser>
   </event>
 </cdbxml>

--- a/tests/ReadModel/Repository/samples/event-copied.xml
+++ b/tests/ReadModel/Repository/samples/event-copied.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cdbxml xmlns="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL/CdbXSD.xsd">
   <event availableto="2100-01-01T01:00:00" cdbid="8b1855f7-7f11-4653-9fbb-f5f4611f7960" createdby="2dotstwice" creationdate="2016-04-15T11:02:38" externalurl="http://foo.be/item/8b1855f7-7f11-4653-9fbb-f5f4611f7960" lastupdated="2016-04-15T11:02:38" lastupdatedby="info@2dotstwice.be" private="false" wfstatus="draft">
+    <keywords>
+      <keyword>Paspartoe</keyword>
+    </keywords>
     <categories>
       <category catid="0.50.6.0.0" type="eventtype">film</category>
       <category catid="1.7.6.0.0" type="theme">Griezelfilm of horror</category>
@@ -38,5 +41,8 @@
       </address>
       <label cdbid="C4ACF936-1D5F-48E8-B2EC-863B313CBDE6">Bibberburcht</label>
     </location>
+    <organiser>
+      <label cdbid="ORG-123">DE Studio</label>
+    </organiser>
   </event>
 </cdbxml>

--- a/tests/ReadModel/Repository/samples/event-with-organizer.xml
+++ b/tests/ReadModel/Repository/samples/event-with-organizer.xml
@@ -47,6 +47,9 @@
       </address>
       <label cdbid="C4ACF936-1D5F-48E8-B2EC-863B313CBDE6">Bibberburcht</label>
     </location>
+    <keywords>
+      <keyword>Paspartoe</keyword>
+    </keywords>
     <organiser>
       <label cdbid="ORG-123">DE Studio</label>
     </organiser>


### PR DESCRIPTION
The default copy behaviour was to remove all labels from the copy. But the UiTPAS label from the organizer should be applied again.