### PR TITLE
Fix incorrect WorkflowStatus namespace

### DIFF
--- a/src/ReadModel/OfferToCdbXmlProjector.php
+++ b/src/ReadModel/OfferToCdbXmlProjector.php
@@ -79,7 +79,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\Events\AbstractFacilitiesUpdated;
 use CultuurNet\UDB3\Offer\Events\AbstractThemeUpdated;
 use CultuurNet\UDB3\Offer\Events\AbstractTypeUpdated;
-use CultuurNet\UDB3\Offer\WorkflowStatus;
+use CultuurNet\UDB3\CdbXmlService\ValueObjects\Offer\WorkflowStatus;
 use CultuurNet\UDB3\Place\Events\ThemeUpdated as PlaceThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated as EventTitleTranslated;
 use CultuurNet\UDB3\Event\Events\OrganizerDeleted as EventOrganizerDeleted;

--- a/src/ValueObjects/Offer/WorkflowStatus.php
+++ b/src/ValueObjects/Offer/WorkflowStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CultuurNet\UDB3\Offer;
+namespace CultuurNet\UDB3\CdbXmlService\ValueObjects\Offer;
 
 use ValueObjects\Enum\Enum;
 


### PR DESCRIPTION
### Fixed

- Fixed incorrect WorkflowStatus namespace. This class was moved from udb3-php but the namespace in the import was never updated