### PR TITLE
III-3530 Fix CLI exceptions not being sent to sentry

### DIFF
--- a/bin/app.php
+++ b/bin/app.php
@@ -4,6 +4,7 @@
 use CultuurNet\SilexAMQP\Console\ConsumeCommand;
 use CultuurNet\UDB3\CdbXmlService\SentryErrorHandler;
 use Knp\Provider\ConsoleServiceProvider;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -34,4 +35,5 @@ try {
     $consoleApp->run();
 } catch (Throwable $throwable) {
     $app[SentryErrorHandler::class]->handle($throwable);
+    $consoleApp->renderException($throwable, new ConsoleOutput());
 }

--- a/bin/app.php
+++ b/bin/app.php
@@ -21,6 +21,7 @@ $app->register(
 
 /** @var \Knp\Console\Application $consoleApp */
 $consoleApp = $app['console'];
+$consoleApp->setCatchExceptions(false);
 
 $consoleApp->add(
     (new ConsumeCommand('consume-udb3-core', 'amqp.udb3-core'))

--- a/src/SentryErrorHandler.php
+++ b/src/SentryErrorHandler.php
@@ -31,7 +31,6 @@ class SentryErrorHandler
         );
 
         $this->sentryHub->captureException($throwable);
-        throw $throwable;
     }
 
     private function createTags(bool $console): array

--- a/web/index.php
+++ b/web/index.php
@@ -32,4 +32,5 @@ try {
     $app->run();
 } catch (Throwable $throwable) {
     $app[SentryErrorHandler::class]->handle($throwable);
+    throw $throwable;
 }


### PR DESCRIPTION
### Fixed

- Fixed CLI exceptions not being sent to Sentry. See https://github.com/cultuurnet/udb3-silex/pull/514/commits/ae165f64e43eff05b03e1b90e2e14f84ce349d05

---

Ticket: https://jira.uitdatabank.be/browse/III-3530